### PR TITLE
PWT-97: Add drush default configs.

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -5,9 +5,21 @@ project:
 
 docroot: ${repo.root}/web
 
+drush:
+  alias-dir: ${repo.root}/drush/sites
+  aliases:
+    local: self
+    ci: self
+  ansi: true
+  bin: ${composer.bin}/drush
+  default_alias: ${drush.aliases.local}
+  dir: ${docroot}
+  sanitize: true
+  alias: ${drush.default_alias}
+
 cm:
   # Possible values: core-only, config-split, none.
-  strategy: config-split
+  strategy: none
   core:
     # The parent directory for configuration directories, relative to the docroot.
     path: ../config

--- a/config/default.yml
+++ b/config/default.yml
@@ -18,10 +18,10 @@ drupal:
       ci: self
     ansi: true
     bin: ${composer.bin}/drush
-    default_alias: ${drush.aliases.local}
+    default_alias: ${drupal.drush.aliases.local}
     dir: ${docroot}
     sanitize: true
-    alias: ${drush.default_alias}
+    alias: ${drupal.drush.default_alias}
   cm:
     # Possible values: core-only, config-split, none.
     strategy: none
@@ -31,7 +31,7 @@ drupal:
       dirs:
         # Corresponding value is defined in config.settings.php.
         sync:
-          path: ${cm.core.path}/default
+          path: ${drupal.cm.core.path}/default
       # Install site directly from existing config.
       # This cannot be used if your install profile implements hook_install.
       install_from_config: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,52 +1,64 @@
-project:
-  recipe: common
+drupal:
+  account:
+    # Admin account name and password will be randomly generated unless set here.
+    #name: admin
+    #pass:
+    mail: no-reply@example.com
+  site.mail: ${drupal.account.mail}
+  locale: en
+  local_settings_file: ${docroot}/sites/${site}/settings/local.settings.php
+  settings_file: ${docroot}/sites/${site}/settings.php
   profile:
     name: minimal
-
-docroot: ${repo.root}/web
-
-drush:
-  alias-dir: ${repo.root}/drush/sites
-  aliases:
-    local: self
-    ci: self
-  ansi: true
-  bin: ${composer.bin}/drush
-  default_alias: ${drush.aliases.local}
-  dir: ${docroot}
-  sanitize: true
-  alias: ${drush.default_alias}
-
-cm:
-  # Possible values: core-only, config-split, none.
-  strategy: none
-  core:
-    # The parent directory for configuration directories, relative to the docroot.
-    path: ../config
-    dirs:
-      # Corresponding value is defined in config.settings.php.
-      sync:
-        path: ${cm.core.path}/default
-    # Install site directly from existing config.
-    # This cannot be used if your install profile implements hook_install.
-    install_from_config: false
-
-sync:
-  # By default, files are not synced during sync:refresh.
-  # Set this value to 'true' or pass -D sync.public-files=true
-  # to override this behavior.
-  public-files: false
-  private-files: false
-  # Paths to exclude during file syncing operations.
-  exclude-paths:
-    - styles
-    - css
-    - js
-  commands:
-    - drupal:site:sync:database
-    - drupal:site:sync:files
-    - drupal:site:sync:private-files
-    # To make sure that the states between local and remote are as close to identical as possible before running an update operation.
-    # That's why files needs to be synchronized locally first.
-    # Command order can be changed as per the need in custom polymer.config file.
-    - drupal:update
+  docroot: ${repo.root}/web
+  drush:
+    alias-dir: ${repo.root}/drush/sites
+    aliases:
+      local: self
+      ci: self
+    ansi: true
+    bin: ${composer.bin}/drush
+    default_alias: ${drush.aliases.local}
+    dir: ${docroot}
+    sanitize: true
+    alias: ${drush.default_alias}
+  cm:
+    # Possible values: core-only, config-split, none.
+    strategy: none
+    core:
+      # The parent directory for configuration directories, relative to the docroot.
+      path: ../config
+      dirs:
+        # Corresponding value is defined in config.settings.php.
+        sync:
+          path: ${cm.core.path}/default
+      # Install site directly from existing config.
+      # This cannot be used if your install profile implements hook_install.
+      install_from_config: false
+  setup:
+    # Valid values are install, sync, import.
+    strategy: install
+    # If setup.strategy is import, this file will be imported. File path is
+    # relative to drupal docroot directory.
+    dump-file: null
+    # Arguments to pass to drush si.
+    install-args: "install_configure_form.enable_update_status_module=NULL"
+  sync:
+    # By default, files are not synced during sync:refresh.
+    # Set this value to 'true' or pass -D sync.public-files=true
+    # to override this behavior.
+    public-files: false
+    private-files: false
+    # Paths to exclude during file syncing operations.
+    exclude-paths:
+      - styles
+      - css
+      - js
+    commands:
+      - drupal:site:sync:database
+      - drupal:site:sync:files
+      - drupal:site:sync:private-files
+      # To make sure that the states between local and remote are as close to identical as possible before running an update operation.
+      # That's why files needs to be synchronized locally first.
+      # Command order can be changed as per the need in custom polymer.config file.
+      - drupal:update

--- a/src/Polymer/Plugin/Commands/ConfigCommands.php
+++ b/src/Polymer/Plugin/Commands/ConfigCommands.php
@@ -72,7 +72,7 @@ class ConfigCommands extends TaskBase
         /** @var \DigitalPolygon\PolymerDrupal\Polymer\Plugin\Tasks\DrushTask $task */
         $task = $this->taskDrush();
 
-        $strategy = $this->getConfigValue('cm.strategy');
+        $strategy = $this->getConfigValue('drupal.cm.strategy');
         if ($strategy === 'none') {
             $this->logger->warning("CM strategy set to none in polymer.yml. Polymer will NOT import configuration.");
             // Still clear caches to regenerate frontend assets and such.
@@ -84,7 +84,7 @@ class ConfigCommands extends TaskBase
         // If using core-only or config-split strategies, first check to see if
         // required config is exported.
         if (in_array($strategy, ['core-only', 'config-split'])) {
-            $core_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("cm.core.dirs.sync.path") . '/core.extension.yml';
+            $core_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("drupal.cm.core.dirs.sync.path") . '/core.extension.yml';
 
             if (!file_exists($core_config_file)) {
                 $this->logger->warning("Polymer will NOT import configuration, $core_config_file was not found.");
@@ -170,7 +170,7 @@ class ConfigCommands extends TaskBase
      */
     protected function checkConfigOverrides(): void
     {
-        if (!$this->getConfigValue('cm.allow-overrides') && !$this->isActiveConfigIdentical()) {
+        if (!$this->getConfigValue('drupal.cm.allow-overrides') && !$this->isActiveConfigIdentical()) {
             $task = $this->taskDrush()
             ->stopOnFail()
             ->drush("config-status");
@@ -213,7 +213,7 @@ class ConfigCommands extends TaskBase
      */
     protected function getExportedSiteUuid(): ?string
     {
-        $site_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("cm.core.dirs.sync.path") . '/system.site.yml';
+        $site_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("drupal.cm.core.dirs.sync.path") . '/system.site.yml';
         if (file_exists($site_config_file)) {
             $site_config = Yaml::parseFile($site_config_file);
             if (is_array($site_config) && isset($site_config['uuid'])) {

--- a/src/Polymer/Plugin/Commands/InstallCommand.php
+++ b/src/Polymer/Plugin/Commands/InstallCommand.php
@@ -52,7 +52,7 @@ class InstallCommand extends TaskBase
         /** @var \DigitalPolygon\Polymer\Robo\Tasks\Command[] $commands */
         $commands = [];
         $commands[] = new PolymerCommand('internal:drupal:install');
-        $strategy = $this->getConfigValue('cm.strategy');
+        $strategy = $this->getConfigValue('drupal.cm.strategy');
 
         if (in_array($strategy, ['core-only', 'config-split'])) {
             $commands[] = new PolymerCommand('drupal:config:import');
@@ -135,16 +135,16 @@ class InstallCommand extends TaskBase
         }
 
         /** @var string $project_profile_name */
-        $project_profile_name = $this->getConfigValue('project.profile.name');
+        $project_profile_name = $this->getConfigValue('drupal.profile.name');
 
         /** @var string $setup_install */
-        $setup_install = $this->getConfigValue('setup.install-args');
+        $setup_install = $this->getConfigValue('drupal.setup.install-args');
 
         /** @var string $project_human_name */
         $project_human_name = $this->getConfigValue('project.human_name');
 
         /** @var string $drupal_site_mail */
-        $drupal_site_mail = $this->getConfigValue('drupal.site.mail');
+        $drupal_site_mail = $this->getConfigValue('drupal.drupal.site.mail');
 
         /** @var string $drupal_account_mail */
         $drupal_account_mail = $this->getConfigValue('drupal.account.mail');
@@ -174,12 +174,12 @@ class InstallCommand extends TaskBase
         }
 
         // Install site from existing config if supported.
-        $strategy = $this->getConfigValue('cm.strategy');
-        $install_from_config = $this->getConfigValue('cm.core.install_from_config');
+        $strategy = $this->getConfigValue('drupal.cm.strategy');
+        $install_from_config = $this->getConfigValue('drupal.cm.core.install_from_config');
         $strategy_uses_config = in_array($strategy, ['core-only', 'config-split']);
 
         if ($install_from_config && $strategy_uses_config) {
-            $core_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("cm.core.dirs.sync.path") . '/core.extension.yml';
+            $core_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("drupal.cm.core.dirs.sync.path") . '/core.extension.yml';
             if (file_exists($core_config_file)) {
                 $task->option('existing-config');
             }

--- a/src/Polymer/Plugin/Commands/InstallCommand.php
+++ b/src/Polymer/Plugin/Commands/InstallCommand.php
@@ -144,7 +144,7 @@ class InstallCommand extends TaskBase
         $project_human_name = $this->getConfigValue('project.human_name');
 
         /** @var string $drupal_site_mail */
-        $drupal_site_mail = $this->getConfigValue('drupal.drupal.site.mail');
+        $drupal_site_mail = $this->getConfigValue('drupal.site.mail');
 
         /** @var string $drupal_account_mail */
         $drupal_account_mail = $this->getConfigValue('drupal.account.mail');

--- a/src/Polymer/Plugin/Commands/SyncCommands.php
+++ b/src/Polymer/Plugin/Commands/SyncCommands.php
@@ -46,7 +46,7 @@ class SyncCommands extends TaskBase
     public function sync(): void
     {
         /** @var array<string> $commands */
-        $commands = $this->getConfigValue('sync.commands');
+        $commands = $this->getConfigValue('drupal.sync.commands');
 
         /** @var PolymerCommand[] $polymer_commands */
         $polymer_commands = [];
@@ -101,8 +101,8 @@ class SyncCommands extends TaskBase
         $sync_map = [];
         foreach ($multisites as $multisite) {
             $this->switchSiteContext($multisite);
-            $sync_map[$multisite]['local'] = '@' . $this->getConfigValue('drush.aliases.local');
-            $sync_map[$multisite]['remote'] = '@' . $this->getConfigValue('drush.aliases.remote');
+            $sync_map[$multisite]['local'] = '@' . $this->getConfigValue('drupal.drush.aliases.local');
+            $sync_map[$multisite]['remote'] = '@' . $this->getConfigValue('drupal.drush.aliases.remote');
             $this->say("  * <comment>" . $sync_map[$multisite]['remote'] . "</comment> => <comment>" . $sync_map[$multisite]['local'] . "</comment>");
         }
         $this->say("To modify the set of aliases for syncing, set the values for drush.aliases.local and drush.aliases.remote in docroot/sites/[site]/blt.yml");
@@ -116,8 +116,8 @@ class SyncCommands extends TaskBase
     #[Command(name: 'drupal:site:sync:database', aliases: ['dsdb'])]
     public function syncDb(): Result
     {
-        $local_alias = '@' . $this->getConfigValue('drush.aliases.local');
-        $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
+        $local_alias = '@' . $this->getConfigValue('drupal.drush.aliases.local');
+        $remote_alias = '@' . $this->getConfigValue('drupal.drush.aliases.remote');
 
         $task = $this->taskDrush()
         ->alias('')
@@ -129,7 +129,7 @@ class SyncCommands extends TaskBase
         ->option('create-db');
         $task->drush('cr');
 
-        if ($this->getConfigValue('drush.sanitize')) {
+        if ($this->getConfigValue('drupal.drush.sanitize')) {
             $task->drush('sql-sanitize');
         }
 
@@ -151,7 +151,7 @@ class SyncCommands extends TaskBase
     #[Command(name: 'drupal:site:sync:files', aliases: ['dsf'])]
     public function syncPublicFiles(): Result
     {
-        $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
+        $remote_alias = '@' . $this->getConfigValue('drupal.drush.aliases.remote');
 
         /** @var string $site_dir */
         $site_dir = $this->getConfigValue('site');
@@ -164,7 +164,7 @@ class SyncCommands extends TaskBase
         ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files");
 
         /** @var array<string> $exclude_paths */
-        $exclude_paths = $this->getConfigValue('sync.exclude-paths');
+        $exclude_paths = $this->getConfigValue('drupal.sync.exclude-paths');
         $task->option('exclude-paths', implode(':', $exclude_paths));
         $result = $task->run();
 
@@ -179,7 +179,7 @@ class SyncCommands extends TaskBase
     #[Command(name: 'drupal:site:sync:private-files', aliases: ['dspf'])]
     public function syncPrivateFiles(): Result
     {
-        $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
+        $remote_alias = '@' . $this->getConfigValue('drupal.drush.aliases.remote');
 
         /** @var string $site_dir */
         $site_dir = $this->getConfigValue('site');
@@ -193,7 +193,7 @@ class SyncCommands extends TaskBase
         ->arg($private_files_local_path);
 
         /** @var array<string> $exclude_paths */
-        $exclude_paths = $this->getConfigValue('sync.exclude-paths');
+        $exclude_paths = $this->getConfigValue('drupal.sync.exclude-paths');
         $task->option('exclude-paths', implode(':', $exclude_paths));
         $result = $task->run();
 

--- a/src/Polymer/Plugin/Tasks/DrushTask.php
+++ b/src/Polymer/Plugin/Tasks/DrushTask.php
@@ -266,26 +266,26 @@ class DrushTask extends CommandStack
      */
     protected function init(): void
     {
-        if ($this->getConfig()->get('drush.bin')) {
+        if ($this->getConfig()->get('drupal.drush.bin')) {
             /** @var string $drush_bin */
-            $drush_bin = $this->getConfig()->get('drush.bin');
+            $drush_bin = $this->getConfig()->get('drupal.drush.bin');
             $this->executable = str_replace(' ', '\\ ', $drush_bin);
         } else {
             $this->executable = 'drush';
         }
         if (!isset($this->dir)) {
             /** @var string $drush_dir */
-            $drush_dir = $this->getConfig()->get('drush.dir');
+            $drush_dir = $this->getConfig()->get('drupal.drush.dir');
             $this->dir($drush_dir);
         }
         if (!$this->uri) {
             /** @var string $drush_uri */
-            $drush_uri = $this->getConfig()->get('drush.uri');
+            $drush_uri = $this->getConfig()->get('drupal.drush.uri');
             $this->uri = $drush_uri;
         }
         if (!isset($this->alias)) {
             /** @var string $drush_alias */
-            $drush_alias = $this->getConfig()->get('drush.alias');
+            $drush_alias = $this->getConfig()->get('drupal.drush.alias');
             $this->alias($drush_alias);
         }
 
@@ -295,7 +295,7 @@ class DrushTask extends CommandStack
 
         if (!isset($this->ansi)) {
             /** @var bool $drush_ansi */
-            $drush_ansi = $this->getConfig()->get('drush.ansi');
+            $drush_ansi = $this->getConfig()->get('drupal.drush.ansi');
             $this->ansi($drush_ansi);
         }
 
@@ -374,18 +374,18 @@ class DrushTask extends CommandStack
         }
 
         if (
-            ($this->debug || $this->getConfig()->get('drush.debug'))
-            && $this->getConfig()->get('drush.debug') !== false
+            ($this->debug || $this->getConfig()->get('drupal.drush.debug'))
+            && $this->getConfig()->get('drupal.drush.debug') !== false
         ) {
             $this->option('-vvv');
         } elseif (
-            ($this->veryVerbose || $this->getConfig()->get('drush.veryVerbose'))
-            && $this->getConfig()->get('drush.veryVerbose') !== false
+            ($this->veryVerbose || $this->getConfig()->get('drupal.drush.veryVerbose'))
+            && $this->getConfig()->get('drupal.drush.veryVerbose') !== false
         ) {
             $this->option('-vv');
         } elseif (
-            ($this->verbose || $this->getConfig()->get('drush.verbose'))
-            && $this->getConfig()->get('drush.verbose') !== false
+            ($this->verbose || $this->getConfig()->get('drupal.drush.verbose'))
+            && $this->getConfig()->get('drupal.drush.verbose') !== false
         ) {
             $this->option('-v');
         }


### PR DESCRIPTION
# Closes [PWT-97](https://digitalpolygon.atlassian.net/browse/PWT-97)

## Things covered:
1. Adding default drush configs.
2. Added all configs under `drupal:` key
3. Update all config commands.

[PWT-97]: https://digitalpolygon.atlassian.net/browse/PWT-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a more organized configuration structure for Drupal settings, enhancing clarity and management of site operations.
	- Added new sections for default email settings and installation strategy options.

- **Bug Fixes**
	- Updated configuration retrieval logic to ensure alignment with the new naming conventions.

- **Refactor**
	- Replaced existing configuration keys with a more specific `drupal` prefix, improving consistency across various modules.

- **Chores**
	- Cleaned up configuration handling to reduce conflicts and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->