### PR TITLE
Fixes the polymer multisites config and --uri value.

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -62,3 +62,6 @@ drupal:
       # That's why files needs to be synchronized locally first.
       # Command order can be changed as per the need in custom polymer.config file.
       - drupal:update
+  # Provide a list of sites for Polymer to run commands against.
+  # multisites:
+  #  - default

--- a/src/Polymer/Plugin/Commands/ConfigCommands.php
+++ b/src/Polymer/Plugin/Commands/ConfigCommands.php
@@ -26,13 +26,15 @@ class ConfigCommands extends TaskBase
     public function multisiteUpdateAllCommand(): void
     {
         /** @var array<string> $multisites */
-        $multisites = $this->getConfigValue('multisites');
+        $multisites = $this->getConfigValue('drupal.multisites');
 
         /** @var PolymerCommand $command */
         $command = new PolymerCommand('drupal:update');
         foreach ($multisites as $multisite) {
+            $this->say("Deploying updates to <comment>$multisite</comment>...");
             $this->switchSiteContext($multisite);
             $this->invokeCommand($command);
+            $this->say("Finished deploying updates to $multisite.");
         }
     }
 

--- a/src/Polymer/Plugin/Commands/SettingsCommands.php
+++ b/src/Polymer/Plugin/Commands/SettingsCommands.php
@@ -65,7 +65,7 @@ class SettingsCommands extends TaskBase
     public function generateDatabaseSettingsFiles(): void
     {
         /** @var array<string> $all_sites */
-        $all_sites = $this->getConfigValue('multisites');
+        $all_sites = $this->getConfigValue('drupal.multisites');
         foreach ($all_sites as $site) {
             $is_settings_exist = false;
             $this->switchSiteContext($site);

--- a/src/Polymer/Plugin/Commands/SyncCommands.php
+++ b/src/Polymer/Plugin/Commands/SyncCommands.php
@@ -23,7 +23,7 @@ class SyncCommands extends TaskBase
     public function allSites(): void
     {
         /** @var array<string> $multisites */
-        $multisites = $this->getConfigValue('multisites');
+        $multisites = $this->getConfigValue('drupal.multisites');
         $this->printSyncMap($multisites);
         $continue = $this->confirm("Continue?", true);
         if (!$continue) {
@@ -68,7 +68,7 @@ class SyncCommands extends TaskBase
         $exit_code = 0;
 
         /** @var array<string> $multisites */
-        $multisites = $this->getConfigValue('multisites');
+        $multisites = $this->getConfigValue('drupal.multisites');
 
         $this->printSyncMap($multisites);
         $continue = $this->confirm("Continue?");

--- a/src/Polymer/Plugin/Tasks/DrushTask.php
+++ b/src/Polymer/Plugin/Tasks/DrushTask.php
@@ -280,7 +280,7 @@ class DrushTask extends CommandStack
         }
         if (!$this->uri) {
             /** @var string $drush_uri */
-            $drush_uri = $this->getConfig()->get('drupal.drush.uri');
+            $drush_uri = $this->getConfig()->get('drush.uri');
             $this->uri = $drush_uri;
         }
         if (!isset($this->alias)) {


### PR DESCRIPTION
### Problem/Motivation
1. Moved multisites configs under drupal configs.
2. Fixed the `--uri` value to run commands for multisites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added comments to the configuration file for multisite management, providing guidance on how to specify multiple sites.
  
- **Bug Fixes**
	- Updated configuration retrieval for multisite settings to ensure proper scoping under the `drupal` namespace, enhancing reliability in command execution.

- **Documentation**
	- Improved comments and explanations within various classes to clarify execution flow and configuration usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->