### PR TITLE
Responsibly unpin --site option.

### DIFF
--- a/src/Polymer/Plugin/Commands/ConfigCommands.php
+++ b/src/Polymer/Plugin/Commands/ConfigCommands.php
@@ -32,6 +32,7 @@ class ConfigCommands extends TaskBase
         foreach ($multisites as $multisite) {
             $this->commandInvoker->pinGlobal('--site', $multisite);
             $this->commandInvoker->invokeCommand($io->input(), 'drupal:update');
+            $this->commandInvoker->unpinGlobal('--site');
             $this->say("Finished deploying updates to $multisite.");
         }
     }

--- a/src/Polymer/Plugin/Commands/SyncCommands.php
+++ b/src/Polymer/Plugin/Commands/SyncCommands.php
@@ -34,6 +34,7 @@ class SyncCommands extends TaskBase
             $this->say("Refreshing site <comment>$multisite</comment>...");
             $this->commandInvoker->pinGlobal('--site', $multisite);
             $this->commandInvoker->invokeCommand($io->input(), 'drupal:site:sync');
+            $this->commandInvoker->unpinGlobal('--site');
         }
     }
 
@@ -78,6 +79,7 @@ class SyncCommands extends TaskBase
             $this->say("Refreshing site <comment>$multisite</comment>...");
             $this->commandInvoker->pinGlobal('--site', $multisite);
             $this->commandInvoker->invokeCommand($io->input(), 'drupal:site:sync:database');
+            $this->commandInvoker->unpinGlobal('--site');
         }
 
         return $exit_code;


### PR DESCRIPTION
# Changes

- Unpin `--site` option after previously pinning it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multisite update and synchronization operations by ensuring the global context is properly reset after each process, reducing the risk of unintended behaviors during subsequent actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->