### PR TITLE
PWT-112: Allow Drush 13 to unblock Drupal 11 upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require": {
     "digitalpolygon/polymer": "0.x-dev",
     "digitalpolygon/drupal-upgrade-plugin": "^1.0@dev",
-    "drush/drush": "^12",
+    "drush/drush": "^12 || ^13",
     "php": ">=8.1",
     "webflo/drupal-finder": "^1.3"
   },


### PR DESCRIPTION
# Changes

- Allow `drush/drush:^13` to unblock upgrades to Drupal 11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded dependency compatibility to support additional versions, ensuring broader compatibility for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->