### PR TITLE
Make compatible with latest drupal upgrade plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require": {
     "digitalpolygon/polymer": "0.x-dev",
-    "digitalpolygon/drupal-upgrade-plugin": "^1.0@dev",
+    "digitalpolygon/drupal-upgrade-plugin": "^2@dev",
     "drush/drush": "^12 || ^13",
     "php": ">=8.1",
     "webflo/drupal-finder": "^1.3"

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -76,7 +76,7 @@ class UpgradeCommands extends TaskBase
         $validOptions = ['latest-minor', 'latest-major', 'next-major', 'semantic'];
         $args = [];
         if ($new_version) {
-            $args[] = '--new-version=' . $new_version;
+            $args[] = $new_version;
         } else {
             if (in_array($upgradeStrategy, $validOptions)) {
                 if ($upgradeStrategy === 'semantic') {
@@ -91,7 +91,7 @@ class UpgradeCommands extends TaskBase
         }
         $args = implode(' ', $args);
 
-        return $this->execCommand("$composerPath $command $args --yes --no-interaction");
+        return $this->execCommand("$composerPath $command $args --no-interaction");
     }
 
     /**


### PR DESCRIPTION
# Changes

- Require v2 series of upgrade plugin and update upgrade command to be compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the dependency version for the Drupal upgrade plugin to a newer dev release, positioning the system for upcoming improvements.
  
- **Refactor**
  - Streamlined the upgrade command process by revising how version inputs are handled, resulting in simpler command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->