### PR TITLE
Introduce Upgrade Status and Drupal Rector usage to `drupal:upgrade` command

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -12,6 +12,7 @@ drupal:
     # Valid values are: semantic, latest-minor, next-major, latest-major.
     strategy: latest-minor
     rector:
+      run-on-major-upgrades: true
       command: ${composer.bin}/rector
       config: ${repo.root}/rector.php
       paths:

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,8 @@ drupal:
   upgrade:
     # Valid values are: semantic, latest-minor, next-major, latest-major.
     strategy: latest-minor
+    upgrade-status:
+      ignore-contrib: true
     rector:
       run-on-major-upgrades: true
       command: ${composer.bin}/rector

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,13 @@ drupal:
   upgrade:
     # Valid values are: semantic, latest-minor, next-major, latest-major.
     strategy: latest-minor
+    rector:
+      command: ${composer.bin}/rector
+      config: ${repo.root}/rector.php
+      paths:
+        - ${docroot}/modules/custom
+        - ${docroot}/themes/custom
+        - ${docroot}/profiles/custom
   account:
     # Admin account name and password will be randomly generated unless set here.
     #name: admin

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -155,6 +155,9 @@ class UpgradeCommands extends TaskBase
             $io->error("Configured rector binary file at path $command was not found. Aborting.");
             return 1;
         }
+        if (!file_exists($configFile)) {
+            $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:rector:setup');
+        }
         try {
             foreach ($paths as $path) {
                 try {
@@ -186,6 +189,24 @@ class UpgradeCommands extends TaskBase
         }
 
         return $result;
+    }
+
+    #[Command(name: 'drupal:upgrade:rector:setup', aliases: ['durs'])]
+    public function setupRectorConfiguration(): int {
+        $composerPath = dirname($this->getConfigValue('composer.bin'));
+        $rectorDefaultConfig = $composerPath . '/palantirnet/drupal-rector/rector.php';
+        $repoRoot = $this->getConfigValue('repo.root');
+        $destinationConfigFile = $repoRoot . '/rector.php';
+        if (!file_exists($rectorDefaultConfig)) {
+            $this->logger->error("Rector default configuration file not found at $rectorDefaultConfig.");
+            return 1;
+        }
+        $result = $this->_copy($rectorDefaultConfig, $destinationConfigFile);
+        if ($result->getExitCode() !== 0) {
+            $this->logger->error("Failed to copy rector configuration file from $rectorDefaultConfig to $destinationConfigFile.");
+            return 1;
+        }
+        return 0;
     }
 
     protected function getNonProjectComposerPath(): string|false

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -39,8 +39,8 @@ class UpgradeCommands extends TaskBase
     public function upgrade(ConsoleIO $io, string|null|int $new_version = InputOption::VALUE_REQUIRED): void
     {
         // If upgrading to next major version:
-        // -> Enable upgrade status module and generate report.
         // -> Run rector on custom code.
+        // -> Enable upgrade status module and generate report.
         // -> Run composer update.
         // -> Attempt to apply changes and export.
         $multisites = $this->getConfigValue('drupal.multisite.sites');
@@ -53,6 +53,9 @@ class UpgradeCommands extends TaskBase
         }
         if ($runRectorOnMajorUpgrade && in_array($upgradeStrategy, $validMajorUpgradeOptions)) {
             $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:rector');
+        }
+        if (in_array($upgradeStrategy, $validMajorUpgradeOptions)) {
+            $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:upgrade-status');
         }
         $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:composer', $args);
         foreach ($multisites as $multisite) {
@@ -191,6 +194,11 @@ class UpgradeCommands extends TaskBase
         return $result;
     }
 
+    /**
+     * Copy the default rector configuration file to the project root.
+     *
+     * @return int
+     */
     #[Command(name: 'drupal:upgrade:rector:setup', aliases: ['durs'])]
     public function setupRectorConfiguration(): int {
         $composerPath = dirname($this->getConfigValue('composer.bin'));
@@ -206,6 +214,31 @@ class UpgradeCommands extends TaskBase
             $this->logger->error("Failed to copy rector configuration file from $rectorDefaultConfig to $destinationConfigFile.");
             return 1;
         }
+        return 0;
+    }
+
+    /**
+     * Generate upgrade status report.
+     *
+     * @param ConsoleIO $io
+     * @return int
+     * @throws TaskException
+     */
+    #[Command(name: 'drupal:upgrade:upgrade-status', aliases: ['duus'])]
+    public function executeUpgradeStatus(ConsoleIO $io): int {
+        $ignoreContrib = $this->getConfigValue('drupal.upgrade.upgrade-status.ignore-contrib');
+        $task = $this->taskDrush();
+        $task
+            ->interactive($this->input()->isInteractive())
+            ->stopOnFail()
+            ->drush('pm:enable')
+            ->arg('upgrade_status')
+            ->drush('upgrade_status:analyze')
+            ->option('--all');
+        if ($ignoreContrib) {
+            $task->option('--ignore-contrib');
+        }
+        $task->run();
         return 0;
     }
 

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -149,7 +149,8 @@ class UpgradeCommands extends TaskBase
     #[Command(name: 'drupal:upgrade:rector', aliases: ['dur'])]
     #[Option(name: 'dry-run', description: 'Scan but do not modify code.')]
     #[Option(name: 'hide-diffs', description: 'Hide diffs of changes made.')]
-    public function drupalRector(ConsoleIO $io, bool $dry_run, bool $hide_diffs): int {
+    public function drupalRector(ConsoleIO $io, bool $dry_run, bool $hide_diffs): int
+    {
         $result = 0;
         $paths = $this->getConfigValue('drupal.upgrade.rector.paths', []);
         $command = $this->getConfigValue('drupal.upgrade.rector.command', '${composer.bin}/rector');
@@ -175,12 +176,10 @@ class UpgradeCommands extends TaskBase
                         $commandLine .= " --no-diffs";
                     }
                     $this->execCommand($commandLine);
-                }
-                catch (AbortTasksException $e) {
+                } catch (AbortTasksException $e) {
                     if (2 === $e->getCode()) {
                         $io->info("Rector process identified changes to be made for path $path.");
-                    }
-                    else {
+                    } else {
                         $io->error("Rector process failed for path $path with error code: " . $e->getCode());
                         $result = 1;
                     }
@@ -200,7 +199,8 @@ class UpgradeCommands extends TaskBase
      * @return int
      */
     #[Command(name: 'drupal:upgrade:rector:setup', aliases: ['durs'])]
-    public function setupRectorConfiguration(): int {
+    public function setupRectorConfiguration(): int
+    {
         $composerPath = dirname($this->getConfigValue('composer.bin'));
         $rectorDefaultConfig = $composerPath . '/palantirnet/drupal-rector/rector.php';
         $repoRoot = $this->getConfigValue('repo.root');
@@ -225,7 +225,8 @@ class UpgradeCommands extends TaskBase
      * @throws TaskException
      */
     #[Command(name: 'drupal:upgrade:upgrade-status', aliases: ['duus'])]
-    public function executeUpgradeStatus(ConsoleIO $io): int {
+    public function executeUpgradeStatus(ConsoleIO $io): int
+    {
         $ignoreContrib = $this->getConfigValue('drupal.upgrade.upgrade-status.ignore-contrib');
         $task = $this->taskDrush();
         $task
@@ -260,5 +261,4 @@ class UpgradeCommands extends TaskBase
         }
         return false;
     }
-
 }

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -40,13 +40,19 @@ class UpgradeCommands extends TaskBase
     {
         // If upgrading to next major version:
         // -> Enable upgrade status module and generate report.
-        // -> Run composer update.
         // -> Run rector on custom code.
+        // -> Run composer update.
         // -> Attempt to apply changes and export.
         $multisites = $this->getConfigValue('drupal.multisite.sites');
+        $upgradeStrategy = $this->getConfigValue('drupal.upgrade.strategy');
+        $runRectorOnMajorUpgrade = $this->getConfigValue('drupal.upgrade.rector.run-on-major-upgrades', false);
+        $validMajorUpgradeOptions = ['latest-major', 'next-major'];
         $args = [];
         if ($new_version) {
             $args['--new-version'] = $new_version;
+        }
+        if ($runRectorOnMajorUpgrade && in_array($upgradeStrategy, $validMajorUpgradeOptions)) {
+            $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:rector');
         }
         $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:composer', $args);
         foreach ($multisites as $multisite) {

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -10,6 +10,8 @@ use Consolidation\AnnotatedCommand\Attributes\Option;
 use Consolidation\AnnotatedCommand\Attributes\Usage;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 use DigitalPolygon\PolymerDrupal\Polymer\Plugin\Tasks\LoadDrushTaskTrait;
+use Robo\Exception\AbortTasksException;
+use Robo\Exception\TaskException;
 use Robo\Symfony\ConsoleIO;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -36,6 +38,11 @@ class UpgradeCommands extends TaskBase
     #[Usage(name: 'drupal:upgrade --new-version=10.2.3', description: 'Upgrades Drupal core to version 10.2.3.')]
     public function upgrade(ConsoleIO $io, string|null|int $new_version = InputOption::VALUE_REQUIRED): void
     {
+        // If upgrading to next major version:
+        // -> Enable upgrade status module and generate report.
+        // -> Run composer update.
+        // -> Run rector on custom code.
+        // -> Attempt to apply changes and export.
         $multisites = $this->getConfigValue('drupal.multisite.sites');
         $args = [];
         if ($new_version) {
@@ -44,7 +51,7 @@ class UpgradeCommands extends TaskBase
         $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:composer', $args);
         foreach ($multisites as $multisite) {
             $this->commandInvoker->pinGlobal('--site', $multisite);
-            $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:export');
+            $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:apply-and-export');
             $this->commandInvoker->unpinGlobal('--site');
         }
     }
@@ -108,7 +115,7 @@ class UpgradeCommands extends TaskBase
      *
      * @throws \Robo\Exception\TaskException
      */
-    #[Command(name: 'drupal:upgrade:export', aliases: ['due'])]
+    #[Command(name: 'drupal:upgrade:apply-and-export', aliases: ['due'])]
     public function exportChanges(ConsoleIO $io): void
     {
         $task = $this->taskDrush()
@@ -120,6 +127,59 @@ class UpgradeCommands extends TaskBase
             $task->drush('cex');
         }
         $task->run();
+    }
+
+    /**
+     * Run rector on configured code paths.
+     *
+     * @param ConsoleIO $io
+     * @param bool $dry_run
+     * @param bool $hide_diffs
+     * @return int
+     */
+    #[Command(name: 'drupal:upgrade:rector', aliases: ['dur'])]
+    #[Option(name: 'dry-run', description: 'Scan but do not modify code.')]
+    #[Option(name: 'hide-diffs', description: 'Hide diffs of changes made.')]
+    public function drupalRector(ConsoleIO $io, bool $dry_run, bool $hide_diffs): int {
+        $result = 0;
+        $paths = $this->getConfigValue('drupal.upgrade.rector.paths', []);
+        $command = $this->getConfigValue('drupal.upgrade.rector.command', '${composer.bin}/rector');
+        $configFile = $this->getConfigValue('drupal.upgrade.rector.config');
+        if (!file_exists($command)) {
+            $io->error("Configured rector binary file at path $command was not found. Aborting.");
+            return 1;
+        }
+        try {
+            foreach ($paths as $path) {
+                try {
+                    $commandLine = "$command process $path --no-progress-bar";
+                    if ($dry_run) {
+                        $commandLine .= " --dry-run";
+                    }
+                    if ($configFile) {
+                        $commandLine .= " --config=$configFile";
+                    }
+                    if ($hide_diffs) {
+                        $commandLine .= " --no-diffs";
+                    }
+                    $this->execCommand($commandLine);
+                }
+                catch (AbortTasksException $e) {
+                    if (2 === $e->getCode()) {
+                        $io->info("Rector process identified changes to be made for path $path.");
+                    }
+                    else {
+                        $io->error("Rector process failed for path $path with error code: " . $e->getCode());
+                        $result = 1;
+                    }
+                }
+            }
+        } catch (TaskException $e) {
+            $io->error("We have failed.");
+            $result = 1;
+        }
+
+        return $result;
     }
 
     protected function getNonProjectComposerPath(): string|false
@@ -140,4 +200,5 @@ class UpgradeCommands extends TaskBase
         }
         return false;
     }
+
 }


### PR DESCRIPTION
# Changes

- Introduce `drupal:upgrade:rector` and `drupal:upgrade:upgrade-status` commands to incorporate Rector updates as well as analysis from Upgrade Status module.

Fixes:
- Issue #19 
- Issue #18 