### PR TITLE
Issue #25: Add site config defaults and wrap drupal commands with site option

### DIFF
--- a/src/Polymer/Plugin/Commands/ConfigCommands.php
+++ b/src/Polymer/Plugin/Commands/ConfigCommands.php
@@ -61,7 +61,9 @@ class ConfigCommands extends TaskBase
             'drupal:deploy:hook',
         ];
         foreach ($commands as $command) {
+            $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('site'));
             $this->commandInvoker->invokeCommand($io->input(), $command);
+            $this->commandInvoker->unpinGlobal('--site');
         }
     }
 

--- a/src/Polymer/Plugin/Commands/InstallCommand.php
+++ b/src/Polymer/Plugin/Commands/InstallCommand.php
@@ -50,7 +50,9 @@ class InstallCommand extends TaskBase
             $commands[] = 'drupal:config:import';
         }
         foreach ($commands as $command) {
+            $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('--site'));
             $this->commandInvoker->invokeCommand($io->input(), $command);
+            $this->commandInvoker->unpinGlobal('--site');
         }
         $this->setSitePermissions();
     }

--- a/src/Polymer/Plugin/Commands/InstallCommand.php
+++ b/src/Polymer/Plugin/Commands/InstallCommand.php
@@ -50,7 +50,7 @@ class InstallCommand extends TaskBase
             $commands[] = 'drupal:config:import';
         }
         foreach ($commands as $command) {
-            $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('--site'));
+            $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('site'));
             $this->commandInvoker->invokeCommand($io->input(), $command);
             $this->commandInvoker->unpinGlobal('--site');
         }

--- a/src/Polymer/Plugin/Commands/SyncCommands.php
+++ b/src/Polymer/Plugin/Commands/SyncCommands.php
@@ -55,7 +55,7 @@ class SyncCommands extends TaskBase
         /** @var array<string> $commands */
         $commands = $this->getConfigValue('drupal.sync.commands');
 
-        $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('--site'));
+        $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('site'));
         foreach ($commands as $command) {
             $this->commandInvoker->invokeCommand($io->input(), $command);
         }

--- a/src/Polymer/Plugin/Commands/SyncCommands.php
+++ b/src/Polymer/Plugin/Commands/SyncCommands.php
@@ -55,9 +55,11 @@ class SyncCommands extends TaskBase
         /** @var array<string> $commands */
         $commands = $this->getConfigValue('drupal.sync.commands');
 
+        $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('--site'));
         foreach ($commands as $command) {
             $this->commandInvoker->invokeCommand($io->input(), $command);
         }
+        $this->commandInvoker->unpinGlobal('--site');
     }
 
     /**

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -41,7 +41,9 @@ class UpgradeCommands extends TaskBase
         if ($new_version) {
             $args['--new-version'] = $new_version;
         }
+        $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('--site'));
         $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:composer', $args);
+        $this->commandInvoker->unpinGlobal('--site');
         foreach ($multisites as $multisite) {
             $this->commandInvoker->pinGlobal('--site', $multisite);
             $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:export');

--- a/src/Polymer/Plugin/Commands/UpgradeCommands.php
+++ b/src/Polymer/Plugin/Commands/UpgradeCommands.php
@@ -41,7 +41,7 @@ class UpgradeCommands extends TaskBase
         if ($new_version) {
             $args['--new-version'] = $new_version;
         }
-        $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('--site'));
+        $this->commandInvoker->pinGlobal('--site', $io->input()->getOption('site'));
         $this->commandInvoker->invokeCommand($io->input(), 'drupal:upgrade:composer', $args);
         $this->commandInvoker->unpinGlobal('--site');
         foreach ($multisites as $multisite) {

--- a/src/Polymer/Services/EventSubscriber/ContextProvidersSubscriber.php
+++ b/src/Polymer/Services/EventSubscriber/ContextProvidersSubscriber.php
@@ -39,6 +39,9 @@ class ContextProvidersSubscriber implements EventSubscriberInterface
             $loader = new YamlConfigLoader();
             $drupalConfig[$configId] = $loader->load($file)->export();
         }
+        if (!empty($possibleConfigFiles['site'])) {
+            $drupalConfig['site'] = array_merge($drupalConfig['site'], $this->getDefaultConfig($site));
+        }
         $event->addContexts($drupalConfig);
     }
 
@@ -53,5 +56,12 @@ class ContextProvidersSubscriber implements EventSubscriberInterface
             ],
         ];
         return $events;
+    }
+
+    protected function getDefaultConfig(string $site): array
+    {
+        $defaultConfig['drupal']['cm']['core']['dirs']['sync']['path'] = '../config/' . $site;
+        $defaultConfig['drupal']['drush']['uri'] = $site;
+        return $defaultConfig;
     }
 }


### PR DESCRIPTION
# Changes

- Add reasonable defaults for multisite-related configuration.
- Wrap drupal-related commands with site option to ensure that expected configuration is used.

Fixes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically merges a default configuration into the site context when a site config file is present, improving configuration management.

- **Bug Fixes**
  - Ensured the global `--site` option is explicitly set for all relevant commands during configuration import, deployment, installation, synchronization, and upgrade processes, resulting in more reliable site-specific operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->